### PR TITLE
Fix parse method on TIN class: https://psalm.dev/078

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020-2023 Thomas Portelange, Pol Dellaiera
+Copyright (c) 2020-2024 Thomas Portelange, Pol Dellaiera
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/composer.json
+++ b/composer.json
@@ -42,10 +42,10 @@
     },
     "config": {
         "allow-plugins": {
+            "ergebnis/composer-normalize": true,
             "infection/extension-installer": true,
-            "phpstan/extension-installer": true,
             "phpro/grumphp": true,
-            "ergebnis/composer-normalize": true
+            "phpstan/extension-installer": true
         }
     },
     "scripts": {

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -7,3 +7,9 @@ parameters:
     extra_tasks:
         phpspec:
             verbose: true
+        infection:
+            threads: 10
+            test_framework: phpspec
+            configuration: infection.json
+            min_msi: 50
+            min_covered_msi: 50

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -7,9 +7,3 @@ parameters:
     extra_tasks:
         phpspec:
             verbose: true
-        infection:
-            threads: 10
-            test_framework: phpspec
-            configuration: infection.json
-            min_msi: 50
-            min_covered_msi: 50

--- a/src/Exception/TINException.php
+++ b/src/Exception/TINException.php
@@ -16,6 +16,11 @@ use Exception;
  */
 final class TINException extends Exception
 {
+    public static function emptySlug(): TINException
+    {
+        return new self('Invalid Slug. Reason: Void string.');
+    }
+
     public static function invalidCountry(string $countryCode): TINException
     {
         return new self(sprintf('No handler available for this country code: %s.', $countryCode));

--- a/src/TIN.php
+++ b/src/TIN.php
@@ -145,9 +145,13 @@ final class TIN
      */
     private function parse(string $slug): array
     {
-        return array_combine(
-            ['country', 'tin'],
-            sscanf($slug, '%2s%s')
-        );
+        if (1 !== preg_match('~(?P<country>^\w{2})(?P<tin>.+$)~', $slug, $parsed)) {
+            throw TINException::invalidSyntax($slug);
+        }
+
+        return [
+            'country' => $parsed['country'],
+            'tin' => $parsed['tin'],
+        ];
     }
 }

--- a/src/TIN.php
+++ b/src/TIN.php
@@ -149,7 +149,7 @@ final class TIN
             throw TINException::emptySlug();
         }
 
-        sscanf($slug, '%2s%s', $country, $tin);
+        [$country, $tin] = sscanf($slug, '%2s%s') + [null, null];
 
         return [
             'country' => (string) $country,

--- a/src/TIN.php
+++ b/src/TIN.php
@@ -149,7 +149,12 @@ final class TIN
             throw TINException::emptySlug();
         }
 
-        [$country, $tin] = sscanf($slug, '%2s%s') + [null, null];
+        /**
+         * @psalm-suppress PossiblyUndefinedArrayOffset
+         * @psalm-suppress PossiblyNullArrayAccess
+         */
+        // @phpstan-ignore-next-line
+        [$country, $tin] = sscanf($slug, '%2s%s');
 
         return [
             'country' => (string) $country,

--- a/src/TIN.php
+++ b/src/TIN.php
@@ -145,13 +145,15 @@ final class TIN
      */
     private function parse(string $slug): array
     {
-        if (1 !== preg_match('~(?P<country>^\w{2})(?P<tin>.+$)~', $slug, $parsed)) {
-            throw TINException::invalidSyntax($slug);
+        if ('' === $slug) {
+            throw TINException::emptySlug();
         }
 
+        sscanf($slug, '%2s%s', $country, $tin);
+
         return [
-            'country' => $parsed['country'],
-            'tin' => $parsed['tin'],
+            'country' => (string) $country,
+            'tin' => (string) $tin,
         ];
     }
 }

--- a/src/TIN.php
+++ b/src/TIN.php
@@ -141,7 +141,7 @@ final class TIN
     /**
      * @throws TINException
      *
-     * @return array<string, string>
+     * @return non-empty-array<'country'|'tin', string>
      */
     private function parse(string $slug): array
     {
@@ -149,12 +149,7 @@ final class TIN
             throw TINException::emptySlug();
         }
 
-        /**
-         * @psalm-suppress PossiblyUndefinedArrayOffset
-         * @psalm-suppress PossiblyNullArrayAccess
-         */
-        // @phpstan-ignore-next-line
-        [$country, $tin] = sscanf($slug, '%2s%s');
+        [$country, $tin] = sscanf($slug, '%2s%s') + ['', ''];
 
         return [
             'country' => (string) $country,


### PR DESCRIPTION
This PR

- [x] Fix parse method
- [x] Updated Copyright Year in LICENSE File
- [x] Normalized composer.json File

When run ```./vendor/bin/grumphp run``` psalm error is raised:
```
···
Running task 10/13: phpstan... ✘
Running task 11/13: psalm... ✘
···
phpstan
=======

------ ---------------------------------------------------------------------------------------------------
  Line   TIN.php
 ------ ---------------------------------------------------------------------------------------------------
  :150   Parameter #2 $values of function array_combine expects array, array<int, string|null>|null given.
 ------ ---------------------------------------------------------------------------------------------------


 [ERROR] Found 1 error


Note: Using configuration file E:\usr\GitHub\tin\phpstan.neon.

psalm
=====

ERROR: PossiblyNullArgument - src/TIN.php:150:13 - Argument 2 of array_combine cannot be null, possibly null value provided (see https://psalm.dev/078)
            sscanf($slug, '%2s%s')


------------------------------
1 errors found
------------------------------
4 other issues found.
You can display them with --show-info=true
------------------------------

```

Whith this PR that error is fixed and pass all checks ok.
