### PR TITLE
Add "clean" option to be able to avoid preg_replace if you need

### DIFF
--- a/src/CountryHandler/CountryHandler.php
+++ b/src/CountryHandler/CountryHandler.php
@@ -22,17 +22,22 @@ abstract class CountryHandler implements CountryHandlerInterface
      * @var string
      */
     private $tin;
+    private $clean;
 
     /**
      * CountryHandler constructor.
      */
-    final public function __construct(string $tin = '')
+    final public function __construct(string $tin = '', ?bool $clean = true)
     {
         $this->tin = $tin;
+        $this->clean = $clean;
     }
 
     public function getTIN(): string
     {
+        if (!$this->clean) {
+            return strtoupper($this->tin);
+        }
         if (null !== $string = preg_replace('#[^[:alnum:]\-+]#u', '', $this->tin)) {
             return strtoupper($string);
         }

--- a/src/TIN.php
+++ b/src/TIN.php
@@ -83,10 +83,12 @@ final class TIN
      * @var string
      */
     private $slug;
+    private $clean;
 
-    private function __construct(string $slug)
+    private function __construct(string $slug, bool $clean)
     {
         $this->slug = $slug;
+        $this->clean = $clean;
     }
 
     /**
@@ -99,14 +101,14 @@ final class TIN
         return $this->getAlgorithm($parsedTin['country'], $parsedTin['tin'])->validate();
     }
 
-    public static function from(string $countryCode, string $tin): TIN
+    public static function from(string $countryCode, string $tin, ?bool $clean = true): TIN
     {
-        return self::fromSlug($countryCode . $tin);
+        return self::fromSlug($countryCode . $tin, $clean);
     }
 
-    public static function fromSlug(string $slug): TIN
+    public static function fromSlug(string $slug, ?bool $clean = true): TIN
     {
-        return new self($slug);
+        return new self($slug, $clean);
     }
 
     public function isValid(): bool
@@ -127,7 +129,7 @@ final class TIN
     {
         foreach ($this->algorithms as $algorithm) {
             if (true === $algorithm::supports($country)) {
-                $handler = new $algorithm($tin);
+                $handler = new $algorithm($tin, $this->clean);
 
                 if ($handler instanceof CountryHandlerInterface) {
                     return $handler;


### PR DESCRIPTION
Hi, I want to use this great library to test TAX numbers, but I dont want to use preg_replace, because, for example, it cleans "."

With this PR user is able to choose if they want to check the real string (it is only uppered case) or he/she wants to "clean it".

See this function in my PR vs original code.

https://github.com/loophp/tin/blob/39e5f92b29db3bd8f132cf2490a7aa89e7677488/src/CountryHandler/CountryHandler.php#L34

https://github.com/ortegafernando/tin/blob/4a3cce4fa8e129385840ccf25b9d17aab6d88ccb/src/CountryHandler/CountryHandler.php#L36

Only this code added to this function:
```       
if (!$this->clean) {
     return strtoupper($this->tin);
}
```

I think it doesn't hurt and can solve my and other's problem. 

Regards,