### PR TITLE
Strict mode: Fix readme.md and fix getTIN function

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ TIN::fromSlug('be7110.2512345')->check(); // Not strict
 TIN::fromSlug('be7110.2512345')->check(strict: false); // Not strict
 TIN::fromSlug('be7110.2512345')->check(true); // Strict
 TIN::fromSlug('be7110.2512345')->check(strict: true); // Strict
-
+```
 
 ## Installation
 

--- a/src/CountryHandler/CountryHandler.php
+++ b/src/CountryHandler/CountryHandler.php
@@ -33,11 +33,7 @@ abstract class CountryHandler implements CountryHandlerInterface
 
     public function getTIN(): string
     {
-        if (null !== $string = preg_replace('#[^[:alnum:]\-+]#u', '', $this->tin)) {
-            return strtoupper($string);
-        }
-
-        return '';
+        return strtoupper($this->tin);
     }
 
     final public static function supports(string $country): bool

--- a/src/TIN.php
+++ b/src/TIN.php
@@ -120,6 +120,17 @@ final class TIN
         return true;
     }
 
+    public function hasAlgorithm(): bool
+    {
+        $parsedTin = $this->parse($this->slug, false);
+        foreach ($this->algorithms as $algorithm) {
+            if (true === $algorithm::supports($parsedTin['country'])) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
     /**
      * @throws TINException
      */

--- a/src/TIN.php
+++ b/src/TIN.php
@@ -119,17 +119,6 @@ final class TIN
 
         return true;
     }
-
-    public function hasAlgorithm(): bool
-    {
-        $parsedTin = $this->parse($this->slug, false);
-        foreach ($this->algorithms as $algorithm) {
-            if (true === $algorithm::supports($parsedTin['country'])) {
-                return true;
-            }
-        }
-        return false;
-    }
     
     /**
      * @throws TINException


### PR DESCRIPTION
Hi, I have updated readme.md file and also fix getTIN function to return only upper version of TIN. 

Before:
```
    public function getTIN(): string
    {
        if (null !== $string = preg_replace('#[^[:alnum:]\-+]#u', '', $this->tin)) {
            return strtoupper($string);
        }
        return '';
    }
```

After:

```
    public function getTIN(): string
    {
        return strtoupper($this->tin);
    }
```

Otherwise, validate function using this ```$tin = $this->getTIN();``` at the beginning is not using the correct stricted version of TIN. 

The place in where TIN is "normalized" is in your new parse function, so there is not necessary to normalized it again in getTIN funcion.

NOTE: if you want, you can even publish getTIN() as this:
```
    public function getTIN(): string
    {
        return $this->tin;
    }
```
but I think that strtoupper function doesnt hurt.